### PR TITLE
Trying out FUSE

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,6 +16,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Install libfuse-dev
+      run: sudo apt-get install libfuse-dev
     - name: Build
       run: cargo build --verbose
     - name: Run tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,6 +25,9 @@ name = "backup-fam"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "fuse",
+ "libc",
+ "time",
 ]
 
 [[package]]
@@ -32,6 +35,12 @@ name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+
+[[package]]
+name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "clap"
@@ -46,6 +55,19 @@ dependencies = [
  "textwrap",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "fuse"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80e57070510966bfef93662a81cb8aa2b1c7db0964354fa9921434f04b9e8660"
+dependencies = [
+ "libc",
+ "log 0.3.9",
+ "pkg-config",
+ "thread-scoped",
+ "time",
 ]
 
 [[package]]
@@ -64,6 +86,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2448f6066e80e3bfc792e9c98bf705b4b0fc6e8ef5b43e5889aff0eaa9c58743"
 
 [[package]]
+name = "log"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
+dependencies = [
+ "log 0.4.11",
+]
+
+[[package]]
+name = "log"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
+
+[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -79,6 +125,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread-scoped"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcbb6aa301e5d3b0b5ef639c9a9c7e2f1c944f177b460c04dc24c69b1fa2bd99"
+
+[[package]]
+name = "time"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+dependencies = [
+ "libc",
+ "wasi",
+ "winapi",
+]
+
+[[package]]
 name = "unicode-width"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,6 +152,12 @@ name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+
+[[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,9 @@ default-run = "backup-fam"
 
 [dependencies]
 clap = "2.33.3"
+fuse = "0.3.1"
+libc = "0.2.33"
+time = "0.1.38"
 
 # CLI for interactions with background file monitoring process
 [[bin]]

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,15 +1,14 @@
-use std::io::Result; 
+use std::io::Result;
 
 #[allow(dead_code)]
 struct AppConfig {
     watched_dirs: Vec<&'static str>,
-    contribution_in_bytes: u64
+    contribution_in_bytes: u64,
 }
-
 
 pub fn init() -> Result<()> {
     println!("Starting file monitoring");
 
     // Main daemon loop
-    loop {};
+    loop {}
 }

--- a/src/bin/cli/main.rs
+++ b/src/bin/cli/main.rs
@@ -1,29 +1,86 @@
-use clap::{Arg, App, SubCommand};
+use clap::{App, Arg, SubCommand};
+use std::path::Path;
+
+mod watched_fs;
 
 const VERSION: &'static str = env!("CARGO_PKG_VERSION");
 
 fn main() {
     let matches = App::new("Backup Fam")
         .version(VERSION)
-        .subcommand(SubCommand::with_name("add-watch")
-              .about("Adds a directory to be watched.")
-              .arg(Arg::with_name("directory")
-                  .takes_value(true)))
-        .subcommand(SubCommand::with_name("set-contribution")
-              .about("Sets the contribution size in bytes.")
-              .arg(Arg::with_name("contribution")
-                   .takes_value(true)))
+        .subcommand(
+            SubCommand::with_name("add-watch")
+                .about("Adds a directory to be watched.")
+                .arg(Arg::with_name("directory").takes_value(true)),
+        )
+        .subcommand(
+            SubCommand::with_name("set-contribution")
+                .about("Sets the contribution size in bytes.")
+                .arg(Arg::with_name("contribution").takes_value(true)),
+        )
+        .subcommand(
+            SubCommand::with_name("try-fuse")
+                .about("Try out fuse.")
+                .arg(
+                    Arg::with_name("backing directory")
+                        .short("-b")
+                        .long("--backing-directory")
+                        .required(true)
+                        .takes_value(true)
+                        .help("The backing directory for the FUSE mount."),
+                )
+                .arg(
+                    Arg::with_name("mount directory")
+                        .short("-m")
+                        .long("--mount-directory")
+                        .required(true)
+                        .takes_value(true)
+                        .help("The mount directory for the FUSE mount."),
+                ),
+        )
         .get_matches();
 
     // TODO: add implementations when strategy for interacting with
-    // background monitoring process has been determined. 
-    match matches.subcommand_name() {
-        Some("add-watch")        => {
+    // background monitoring process has been determined.
+    match matches.subcommand() {
+        ("add-watch", _) => {
             unimplemented!("add-watch command not implemented");
-        },
-        Some("set-contribution") => {
+        }
+        ("set-contribution", _) => {
             unimplemented!("set-contribution command not implemented");
-        },
+        }
+        ("try-fuse", Some(sub_matches)) => {
+            let mount_dir = sub_matches.value_of("mount directory").unwrap();
+            let backing_dir = sub_matches.value_of("backing directory").unwrap();
+            println!(
+                "Trying fuse, will mount at {}, backing to {}",
+                mount_dir, backing_dir
+            );
+            let mount_dir = Path::new(mount_dir);
+            let backing_dir = Path::new(backing_dir);
+            match (check_directory(&mount_dir), check_directory(&backing_dir)) {
+                (Ok(_), Ok(_)) => {
+                    watched_fs::watch_filesystem(mount_dir, backing_dir);
+                }
+                (Err(mount_dir_message), _) => {
+                    eprintln!("Mount directory is bad: {}", mount_dir_message);
+                }
+                (_, Err(backing_dir_message)) => {
+                    eprintln!("Mount directory is bad: {}", backing_dir_message);
+                }
+            }
+        }
         _ => {}
+    }
+}
+
+/// Checks a potential directory for existence and directory-ness.
+fn check_directory(directory: &Path) -> Result<(), String> {
+    if !directory.exists() {
+        Err(directory.to_string_lossy().into_owned() + " does not exist!")
+    } else if !directory.is_dir() {
+        Err(directory.to_string_lossy().into_owned() + " is not a directory!")
+    } else {
+        Ok(())
     }
 }

--- a/src/bin/cli/watched_fs.rs
+++ b/src/bin/cli/watched_fs.rs
@@ -1,0 +1,294 @@
+use std::ffi::OsStr;
+use std::path::Path;
+use std::path::PathBuf;
+
+use fuse::mount;
+use fuse::FileAttr;
+use fuse::FileType;
+use fuse::Filesystem;
+use fuse::ReplyAttr;
+use fuse::ReplyData;
+use fuse::ReplyDirectory;
+use fuse::ReplyEmpty;
+use fuse::ReplyEntry;
+use fuse::ReplyOpen;
+use fuse::Request;
+
+use libc::c_int;
+use libc::ENODATA;
+use libc::ENOENT;
+use libc::ENXIO;
+use libc::EPERM;
+
+use time::Timespec;
+
+/// Watched filesystem watches a filesystem for activity and outputs messages to
+/// stdout as activity occurs.  This implementation uses FUSE and a backing
+/// directory.
+
+struct WatchedFilesystem {
+    _backing_directory: PathBuf,
+}
+
+impl WatchedFilesystem {
+    fn new(backing_directory: &Path) -> WatchedFilesystem {
+        WatchedFilesystem {
+            _backing_directory: backing_directory.to_path_buf(),
+        }
+    }
+}
+
+/// At this point, the WatchedFilesystem presents a single file with fixed context.
+/// It will also spew about a bunch of messages about various methods being called.
+/// (Obviously, only a proof that FUSE can do _something_.
+impl Filesystem for WatchedFilesystem {
+    /// Initialize the filesystem.  Called after mount.
+    fn init(&mut self, _request: &Request) -> Result<(), c_int> {
+        println!("Init");
+        Ok(())
+    }
+
+    /// Presumably called to do tear down, but it's not at the moment.
+    fn destroy(&mut self, _request: &Request) {
+        // This doesn't appear to be called on umount...
+        println!("Destroy")
+    }
+
+    /// Directory entry lookup.
+    fn lookup(&mut self, request: &Request, parent: u64, name: &OsStr, reply: ReplyEntry) {
+        let name = name.to_str().unwrap();
+        println!("Lookup: parent: {}, name: {}", parent, name);
+        match name {
+            "neato" => {
+                let ttl = Timespec::new(1, 0);
+                let file_attr = FileAttr {
+                    ino: 2,
+                    size: 8,
+                    blocks: 1,
+                    atime: time::get_time(),
+                    mtime: time::get_time(),
+                    ctime: time::get_time(),
+                    crtime: time::get_time(),
+                    kind: FileType::RegularFile,
+                    perm: 0b100_000_000,
+                    nlink: 1,
+                    uid: request.uid(),
+                    gid: request.gid(),
+                    rdev: 0,
+                    flags: 0,
+                };
+                reply.entry(&ttl, &file_attr, 0)
+            }
+            _ => {
+                reply.error(ENOENT);
+            }
+        }
+    }
+
+    /// Appears to be part of the resource management.  Every time a lookup or
+    /// create succeeds (and returns a inode), its counter is incremented by one.
+    /// This is the decrement side, indicating that the resource is used by one
+    /// less thing.  This is important to know when resources can be freed.
+    fn forget(&mut self, _request: &Request, inode: u64, num_lookups: u64) {
+        println!("Forget: inode: {}, num_lookups: {}", inode, num_lookups);
+    }
+
+    fn getattr(&mut self, request: &Request, inode: u64, reply: ReplyAttr) {
+        println!("Getattr: inode: {}", inode);
+        // Inode 1 appears to be the 'root' of the filesystem.
+        if inode == 1 {
+            let ttl = Timespec::new(1, 0);
+            let file_attr = FileAttr {
+                ino: inode,
+                size: 1024,
+                blocks: 1,
+                atime: time::get_time(),
+                mtime: time::get_time(),
+                ctime: time::get_time(),
+                crtime: time::get_time(),
+                kind: FileType::Directory,
+                perm: 0b101_000_000,
+                nlink: 1,
+                uid: request.uid(),
+                gid: request.gid(),
+                rdev: 0,
+                flags: 0,
+            };
+            reply.attr(&ttl, &file_attr)
+        } else if inode == 2 {
+            let ttl = Timespec::new(1, 0);
+            let file_attr = FileAttr {
+                ino: inode,
+                size: 8,
+                blocks: 1,
+                atime: time::get_time(),
+                mtime: time::get_time(),
+                ctime: time::get_time(),
+                crtime: time::get_time(),
+                kind: FileType::RegularFile,
+                perm: 0b100_000_000,
+                nlink: 1,
+                uid: request.uid(),
+                gid: request.gid(),
+                rdev: 0,
+                flags: 0,
+            };
+            reply.attr(&ttl, &file_attr)
+        } else {
+            reply.error(ENODATA);
+        }
+    }
+
+    fn setattr(
+        &mut self,
+        _request: &Request,
+        inode: u64,
+        mode: Option<u32>,
+        uid: Option<u32>,
+        gid: Option<u32>,
+        size: Option<u64>,
+        atime: Option<Timespec>,
+        mtime: Option<Timespec>,
+        fh: Option<u64>,
+        crtime: Option<Timespec>,
+        chgtime: Option<Timespec>,
+        bkuptime: Option<Timespec>,
+        flags: Option<u32>,
+        reply: ReplyAttr,
+    ) {
+        println!(
+            "Setattr: inode: {}, mode: {:?}, uid: {:?}, gid: {:?} \
+            size: {:?}, atime: {:?}, mtime: {:?}, fh: {:?}, crtime: {:?} \
+            chgtime: {:?}, bkuptime: {:?}, flags: {:?}",
+            inode, mode, uid, gid, size, atime, mtime, fh, crtime, chgtime, bkuptime, flags
+        );
+        reply.error(EPERM);
+    }
+
+    fn opendir(&mut self, _request: &Request, inode: u64, flags: u32, reply: ReplyOpen) {
+        println!("Opendir: inode: {}, flags: {}", inode, flags);
+        if inode == 1 {
+            let file_handle: u64 = 0; // Don't need a file handle at this point in faking it.
+            reply.opened(file_handle, flags);
+        } else {
+            reply.error(EPERM);
+        }
+    }
+
+    fn readdir(
+        &mut self,
+        _request: &Request,
+        inode: u64,
+        handle: u64,
+        offset: i64,
+        mut reply: ReplyDirectory,
+    ) {
+        println!(
+            "Readdir: inode: {}, handle: {}, offset: {}",
+            inode, handle, offset
+        );
+        match (inode, offset) {
+            (1, 0) => {
+                reply.add(2, 1, FileType::RegularFile, "neato"); // Assuming at least one entry can be added.
+                reply.ok();
+            }
+            (1, 1) => {
+                reply.ok();
+            }
+            (_, _) => {
+                reply.error(EPERM);
+            }
+        }
+    }
+
+    fn releasedir(
+        &mut self,
+        _request: &Request,
+        inode: u64,
+        handle: u64,
+        flags: u32,
+        reply: ReplyEmpty,
+    ) {
+        println!(
+            "Releasedir: inode: {}, handle: {}, flags: {}",
+            inode, handle, flags
+        );
+        if inode == 1 {
+            reply.ok();
+        } else {
+            reply.error(EPERM);
+        }
+    }
+
+    fn open(&mut self, _request: &Request, inode: u64, flags: u32, reply: ReplyOpen) {
+        println!("Open: inode: {}, flags: {}", inode, flags);
+        if inode == 2 {
+            let file_handle: u64 = 42;
+            reply.opened(file_handle, flags);
+        } else {
+            reply.error(EPERM);
+        }
+    }
+
+    fn read(
+        &mut self,
+        _request: &Request,
+        inode: u64,
+        file_handle: u64,
+        offset: i64,
+        size: u32,
+        reply: ReplyData,
+    ) {
+        println!(
+            "Read: inode: {}, file_handle: {}, offset: {}, size: {}",
+            inode, file_handle, offset, size
+        );
+        let data = "burrito\n".as_bytes();
+        let offset = offset as usize;
+        let size = size as usize;
+        match (inode, file_handle) {
+            (2, 42) => {
+                if offset < 8 {
+                    let end = usize::min(8, offset + size);
+                    reply.data(&data[offset..end]);
+                } else {
+                    reply.error(ENXIO);
+                }
+            }
+            _ => {
+                reply.error(ENXIO);
+            }
+        }
+    }
+
+    fn release(
+        &mut self,
+        _request: &Request,
+        inode: u64,
+        file_handle: u64,
+        flags: u32,
+        lock_owner: u64,
+        flush: bool,
+        reply: ReplyEmpty,
+    ) {
+        println!(
+            "Release: inode: {}, file_handle: {}, flags: {}, lock_owner: {}, flush: {}",
+            inode, file_handle, flags, lock_owner, flush
+        );
+        reply.ok();
+    }
+}
+
+pub fn watch_filesystem(mount_point: &Path, backing_directory: &Path) {
+    let watched_fs = WatchedFilesystem::new(backing_directory);
+    let options: &[&OsStr] = &[];
+    let result = mount(watched_fs, &mount_point, options);
+    match result {
+        Ok(_) => {
+            println!("Unmounted");
+        }
+        Err(error) => {
+            eprintln!("Failed: {}", error);
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,8 @@
-mod app; 
+mod app;
 
 use std::io::Result;
 
-fn main() -> Result<()>{
-    app::init()?; 
+fn main() -> Result<()> {
+    app::init()?;
     Ok(())
 }


### PR DESCRIPTION
Trying out the fuse crate.  Note that I added the installation of libfuse-dev to the Github action - it's needed to use the fuse crate.

The aim is to create a kind of pass through file system using FUSE to monitor all activity on a backing file system - this is where WatchedFilesystem is heading.  This turned out to be too much to do in one bite.  So, what's implemented currently is a dead simple file system that lives entirely in code - it consists of a single root directory (inode 1) and a single regular file named 'neato', whose contents are 'burrito', followed by a new line.  Both the root directory and file are read only, but that's not properly enforced at the moment.

This is currently part of the CLI executable, not the right place ultimately, but works for now.  To try, run the cli program with a subcommand of try-ruse.  It needs two directories: a directory to use as a mount point and 'backing' directory, though the backing directory isn't used.  These are specified using the -m and -b arguments.  Once running, the program will 'hang' waiting for activity at the mount point - for select activity, messages will be written to stdout.

The proper way to shutdown the program is to run `fusermount -u <mount point>`.  Killing it will leave things in a weird state, but that state can be corrected with the same fusermount command.