### PR TITLE
Add daemon process configuration

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,13 +1,23 @@
 use std::io::Result;
+use std::path::PathBuf;
 
-#[allow(dead_code)]
-struct AppConfig {
-    watched_dirs: Vec<&'static str>,
-    contribution_in_bytes: u64,
+pub struct Config {
+    pub watched_dirs: Vec<PathBuf>,
+    pub contribution_in_bytes: u64,
 }
 
-pub fn init() -> Result<()> {
+impl Config {
+    pub fn print(&self) {
+        println!("Configured watched directories");
+        self.watched_dirs.iter().for_each(|dir_path| {
+            println!("    - {}", dir_path.to_str().unwrap());
+        });
+    }
+}
+
+pub fn init(config: &Config) -> Result<()> {
     println!("Starting file monitoring");
+    config.print();
 
     // Main daemon loop
     loop {}

--- a/src/bin/cli/main.rs
+++ b/src/bin/cli/main.rs
@@ -6,7 +6,7 @@ mod watched_fs;
 const VERSION: &'static str = env!("CARGO_PKG_VERSION");
 
 fn main() {
-    let matches = App::new("Backup Fam")
+    let matches = App::new("Backup Fam -- CLI")
         .version(VERSION)
         .subcommand(
             SubCommand::with_name("add-watch")

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ fn main() -> Result<()> {
             Arg::with_name("directory")
                 .short("d")
                 .multiple(true)
-                .takes_value(true)
+                .takes_value(true),
         )
         .get_matches();
 
@@ -22,13 +22,13 @@ fn main() -> Result<()> {
         .unwrap()
         .map(|dir_arg| PathBuf::from(dir_arg))
         .collect();
-    
+
     let config = app::Config {
         watched_dirs,
         // TODO: add contribution arg handling and byte unit ('gb', 'mb', ...) parsing.
-        contribution_in_bytes: 10
+        contribution_in_bytes: 10,
     };
-    
+
     app::init(&config)?;
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,34 @@
+use clap::{App, Arg};
 mod app;
 
 use std::io::Result;
+use std::path::PathBuf;
+
+const VERSION: &'static str = env!("CARGO_PKG_VERSION");
 
 fn main() -> Result<()> {
-    app::init()?;
+    let matches = App::new("Backup Fam -- Monitoring")
+        .version(VERSION)
+        .arg(
+            Arg::with_name("directory")
+                .short("d")
+                .multiple(true)
+                .takes_value(true)
+        )
+        .get_matches();
+
+    let watched_dirs: Vec<PathBuf> = matches
+        .values_of("directory")
+        .unwrap()
+        .map(|dir_arg| PathBuf::from(dir_arg))
+        .collect();
+    
+    let config = app::Config {
+        watched_dirs,
+        // TODO: add contribution arg handling and byte unit ('gb', 'mb', ...) parsing.
+        contribution_in_bytes: 10
+    };
+    
+    app::init(&config)?;
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ fn main() -> Result<()> {
         )
         .get_matches();
 
+    // TODO: add directory exists assertions.
     let watched_dirs: Vec<PathBuf> = matches
         .values_of("directory")
         .unwrap()


### PR DESCRIPTION
Allows for watch paths to be configured with the '-d' option. Multiple '-d' args can be specified for multiple directories. 
```
cargo run -- -d 'test1' -d 'test2'
```
 `-d` args will be saved to a `Vec<PathBuf>` field on an instance of the `app::Config` struct. 